### PR TITLE
46 minigrid data output bug

### DIFF
--- a/examples/records/minigrid_human_f8d37546-debe-4545-9853-7b5c8d90f800.json
+++ b/examples/records/minigrid_human_f8d37546-debe-4545-9853-7b5c8d90f800.json
@@ -1,4 +1,0 @@
-[
-{"episode": 0, "steps": 59, "reward": 0.9292},
-{"episode": 1, "steps": 81, "reward": 0.9028}
-]

--- a/examples/records/minigrid_human_f8d37546-debe-4545-9853-7b5c8d90f800.json
+++ b/examples/records/minigrid_human_f8d37546-debe-4545-9853-7b5c8d90f800.json
@@ -1,0 +1,4 @@
+[
+{"episode": 0, "steps": 59, "reward": 0.9292},
+{"episode": 1, "steps": 81, "reward": 0.9028}
+]

--- a/requirements-examples.txt
+++ b/requirements-examples.txt
@@ -2,6 +2,9 @@
 gymnasium
 minigrid==2.1
 
+# Lunar Lander
+gym[box2d]>=0.22
+pyglet>=1.5.27
 
 # Crafting
 

--- a/requirements-examples.txt
+++ b/requirements-examples.txt
@@ -3,8 +3,8 @@ gymnasium
 minigrid==2.1
 
 # Lunar Lander
-# gym[box2d]>=0.22
-# pyglet>=1.5.27
+gym[box2d]>=0.22
+pyglet>=1.5.27
 
 # Crafting
 

--- a/requirements-examples.txt
+++ b/requirements-examples.txt
@@ -3,8 +3,8 @@ gymnasium
 minigrid==2.1
 
 # Lunar Lander
-gym[box2d]>=0.22
-pyglet>=1.5.27
+# gym[box2d]>=0.22
+# pyglet>=1.5.27
 
 # Crafting
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 gym>=0.17.2
+atari-py>=0.2.9
 shortuuid>=1.0.1
 asyncio>=3.4.3
 websockets>=10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 gym>=0.17.2
-# atari-py>=0.2.9
+atari-py>=0.2.9
 shortuuid>=1.0.1
 asyncio>=3.4.3
 websockets>=10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 gym>=0.17.2
-atari-py>=0.2.9
+# atari-py>=0.2.9
 shortuuid>=1.0.1
 asyncio>=3.4.3
 websockets>=10.0

--- a/src/hippogym/recorder.py
+++ b/src/hippogym/recorder.py
@@ -45,25 +45,39 @@ class JsonRecorder(Recorder):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.first_record_written = False
+        self.current_file = None
 
-    def write(self, data, outfile: FileIO):
-        if self.first_record_written:
-            outfile.write(",\n")
-        else:
-            self.first_record_written = True
-        outfile.write(json.dumps(data))
+    def write(self, data, filepath: Path):
+        print("Writing data to file:", data)
+        with open(filepath, "r") as file:
+            content = file.read()
+            if content[-2:] == "\n]":
+                content = content[:-2] + ",\n"
+            else:
+                content = content[:-1]  # Remove the last "]" character
+                content += "\n"  # Add newline character
+            content += json.dumps(data) + "\n]"
+        with open(filepath, "w") as file:
+            file.write(content)
+
 
     def close_file(self) -> None:
+        print("Closing file")
         if self.current_file:
             self.current_file.write("\n]")
+            self.current_file.flush()
             self.current_file.close()
             self.current_file = None
             self.first_record_written = False
     def create_file(self, filepath: Path) -> FileIO:
         """Create a new json to record into."""
-        file = open(filepath.with_suffix(".json"), "w")
-        file.write("[\n")
-        return file
+        print(f"Creating file at: {filepath.with_suffix('.json')}")
+        if not os.path.exists(filepath.with_suffix(".json")):
+            file = open(filepath.with_suffix(".json"), "w")
+            file.write("[\n")
+            file.close()
+        return filepath.with_suffix(".json")
+
     def __del__(self):
         self.close_file()
 


### PR DESCRIPTION
For whatever reason, minigrid data wasn't being saved for devices other than my own, after some testing it seems to have fixed by forcing the data to .flush() after retrieval. 


This was tested on MacOS (personal device), Linux Ubuntu and WSL Windows and all worked accordingly now, so on further issues should arise.