### PR TITLE
Docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM python:3.9
 RUN apt-get update && apt-get install -y \
 	xvfb \
 	swig
-
 WORKDIR /src/hippogym
 
 COPY src/hippogym .
@@ -19,8 +18,7 @@ RUN pip3 install -r requirements.txt
 RUN pip3 install -r requirements-examples.txt
 RUN pip3 install pyopengl
 
-ENV PYTHONPATH "${PYTHONPATH}:/hippogym/src"
-
+ENV PYTHONPATH "${PYTHONPATH}:/src"
 EXPOSE 5000
 
 COPY start.sh ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,26 @@ FROM python:3.9
 
 RUN apt-get update && apt-get install -y \
 	xvfb \
-	python-opengl
+	swig
 
-COPY src/* ./
-RUN mkdir ./Trials
+WORKDIR /src/hippogym
+
+COPY src/hippogym .
+COPY examples /src/hippogym/examples
+
+RUN mkdir ../Trials
+
 COPY requirements.txt .
+COPY requirements-examples.txt .
 
 RUN pip3 install --upgrade pip
 RUN pip3 install -r requirements.txt
+RUN pip3 install -r requirements-examples.txt
+RUN pip3 install pyopengl
+
+ENV PYTHONPATH "${PYTHONPATH}:/hippogym/src"
 
 EXPOSE 5000
 
-CMD ./xvfb.sh
+COPY start.sh ./
+CMD ./start.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,11 @@ COPY requirements-examples.txt .
 RUN pip3 install --upgrade pip
 RUN pip3 install -r requirements.txt
 RUN pip3 install -r requirements-examples.txt
-RUN pip3 install pyopengl
+RUN pip3 install pyopengl==3.1.6
 
 ENV PYTHONPATH "${PYTHONPATH}:/src"
+
+ENV HIPPOGYM_HOST 0.0.0.0
 EXPOSE 5000
 
 COPY start.sh ./

--- a/examples/records/minigrid_human_2b5b24b5-36a4-48b6-b374-72025a66911c.json
+++ b/examples/records/minigrid_human_2b5b24b5-36a4-48b6-b374-72025a66911c.json
@@ -1,0 +1,7 @@
+[
+{"episode": 0, "steps": 68, "reward": 0.9184},
+{"episode": 1, "steps": 66, "reward": 0.9208000000000001},
+{"episode": 2, "steps": 48, "reward": 0.9424},
+{"episode": 3, "steps": 52, "reward": 0.9376},
+{"episode": 4, "steps": 72, "reward": 0.9136}
+]

--- a/examples/records/minigrid_human_2b5b24b5-36a4-48b6-b374-72025a66911c.json
+++ b/examples/records/minigrid_human_2b5b24b5-36a4-48b6-b374-72025a66911c.json
@@ -1,7 +1,0 @@
-[
-{"episode": 0, "steps": 68, "reward": 0.9184},
-{"episode": 1, "steps": 66, "reward": 0.9208000000000001},
-{"episode": 2, "steps": 48, "reward": 0.9424},
-{"episode": 3, "steps": 52, "reward": 0.9376},
-{"episode": 4, "steps": 72, "reward": 0.9136}
-]

--- a/src/hippogym/communicator.py
+++ b/src/hippogym/communicator.py
@@ -4,7 +4,7 @@ import ssl
 from logging import getLogger
 from multiprocessing import Queue
 from typing import TYPE_CHECKING, Callable, Optional, Tuple, Union
-
+import os
 from websockets.server import WebSocketServerProtocol, serve
 
 if TYPE_CHECKING:
@@ -150,15 +150,11 @@ class WebSocketCommunicator:
         return out_q.get()
 
 
-async def start_non_ssl_server(handler: Callable, host: str, port: int) -> None:
-    """Start a non-ssl WebSocket server.
 
-    Args:
-        handler (Callable): Function to serve on the websocket.
-        host (str): Host of the websocket server.
-        port (int): Port of the websocket server.
-    """
-    async with serve(handler, host='0.0.0.0', port='5000') as websocket:
+
+async def start_non_ssl_server(handler: Callable, host: str, port: int) -> None:
+    host = os.environ.get('HIPPOGYM_HOST', host)
+    async with serve(handler, host=host, port='5000') as websocket:
         LOGGER.info("Non-SSL websocket started at %s:%i", host, port)
         await websocket.serve_forever()
 

--- a/src/hippogym/communicator.py
+++ b/src/hippogym/communicator.py
@@ -158,7 +158,7 @@ async def start_non_ssl_server(handler: Callable, host: str, port: int) -> None:
         host (str): Host of the websocket server.
         port (int): Port of the websocket server.
     """
-    async with serve(handler, host, port) as websocket:
+    async with serve(handler, host='0.0.0.0', port='5000') as websocket:
         LOGGER.info("Non-SSL websocket started at %s:%i", host, port)
         await websocket.serve_forever()
 

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,2 @@
 #!/bin/bash
-export PYTHONPATH=/src:/src/hippogym:$PYTHONPATH
-
-xvfb-run -s "-screen 0 1400x900x24" python3 /src/hippogym/examples/minigrid_example.py
+xvfb-run -s "-screen 0 1400x900x24" python3 $1

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+export PYTHONPATH=/src:/src/hippogym:$PYTHONPATH
 
-xvfb-run -s "-screen 0 1400x900x24" python3 $1
+xvfb-run -s "-screen 0 1400x900x24" python3 /src/hippogym/examples/minigrid_example.py


### PR DESCRIPTION
When attempting to run the docker container for HippoGym for testing, it would cause errors and not be able to run accordingly. I had to change the file structure of the docker setup to now allow the /examples environments (and theoretically any environments) to run through Docker if you want to test it on a clean machine. 

The current file structure is as follows (from Docker CLI):

```
# ls
__init__.py  agent.py         event_handler.py  log.py              requirements-examples.txt  trial.py
__main__.py  bucketer.py      examples          message_handler.py  requirements.txt           trialsteps
__pycache__  communicator.py  hippogym.py       recorder.py         start.sh                   ui_elements
# cd examples
# ls
grid.py  hcraft_example.py  lunar_lander.py  minigrid_example.py  records
# python minigrid_example.py 
DEBUG:asyncio:Using selector: EpollSelector
INFO:websockets.server:server listening on 0.0.0.0:5000
INFO:hippogym.communicator:Non-SSL websocket started at localhost:5000
```





 